### PR TITLE
Fix temporary directory removal in case of cmd error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.idea
 chrun
 assets/*
+chroot-containers

--- a/chrun.go
+++ b/chrun.go
@@ -52,7 +52,10 @@ func chroot(root string, call string) {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	must(cmd.Run())
+	err = cmd.Run()
+	if err != nil {
+		fmt.Println(err)
+	}
 
 	//Go back to old root
 	//So that we can clean up the temp dir

--- a/chrun.go
+++ b/chrun.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -65,7 +64,7 @@ func createTempDir(name string) string {
 	var nonAlphanumericRegex = regexp.MustCompile(`[^a-zA-Z0-9 ]+`)
 
 	prefix := nonAlphanumericRegex.ReplaceAllString(name, "_")
-	dir, err := ioutil.TempDir("", prefix)
+	dir, err := os.MkdirTemp("", prefix)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Hello,

The issue can be reproduced with the following commands:
```
./chrun pull hello-world
sudo ./chrun run hello-world /hello-fail
ls /tmp | grep hello # should be empty instead
```

I'm not a Go expert, feel free to edit or suggest a better way to solve the problem.

This PR includes other minor changes.