### PR TITLE
Add default command to chrun

### DIFF
--- a/chrun.go
+++ b/chrun.go
@@ -15,8 +15,20 @@ import (
 func main() {
 	switch os.Args[1] {
 	case "run":
-		tar := fmt.Sprintf("./assets/%s.tar.gz", os.Args[2])
-		cmd := os.Args[3]
+		img := os.Args[2]
+		tar := fmt.Sprintf("./assets/%s.tar.gz", img)
+
+		cmd := ""
+		if len(os.Args) > 3 {
+			cmd = os.Args[3]
+		} else {
+			buf, err := os.ReadFile(fmt.Sprintf("./assets/%s-cmd", img))
+			if err != nil {
+				panic(err)
+			}
+			cmd = string(buf)
+		}
+
 		dir := createTempDir(tar)
 		defer os.RemoveAll(dir)
 		must(unTar(tar, dir))

--- a/pull
+++ b/pull
@@ -10,4 +10,6 @@ container=$(docker create "$image")
 docker export "$container" -o "./assets/${image}.tar.gz" > /dev/null
 docker rm "$container" > /dev/null
 
+docker inspect -f '{{.Config.Cmd}}' "$image:latest" | tr -d '[]\n' > "./assets/${image}-cmd"
+
 echo "Image content stored in assets/${image}.tar.gz"

--- a/readme.md
+++ b/readme.md
@@ -76,5 +76,3 @@ And there you go, containers using only chroot.
 ## Caveats
 
 I'm sure there are containers this will not run. PRs and issues welcome.
-
-I'd love to have chrun extract the entrypoint from the manifest and add it as a shell script to the tar, so that the entry-point in `chrun run <imagename> <entry-point>` was optional.


### PR DESCRIPTION
The command is stored in a separate text file rather than inside the .tar.gz to avoid additional operations on the archive (files can't be added directly to an existing .tar.gz archive).