### PR TITLE
davc0n/tar-check

### DIFF
--- a/chrun.go
+++ b/chrun.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -15,14 +16,18 @@ import (
 func main() {
 	switch os.Args[1] {
 	case "run":
-		img := os.Args[2]
-		tar := fmt.Sprintf("./assets/%s.tar.gz", img)
+		image := os.Args[2]
+		tar := fmt.Sprintf("./assets/%s.tar.gz", image)
+
+		if _, err := os.Stat(tar); errors.Is(err, os.ErrNotExist) {
+			panic(err)
+		}
 
 		cmd := ""
 		if len(os.Args) > 3 {
 			cmd = os.Args[3]
 		} else {
-			buf, err := os.ReadFile(fmt.Sprintf("./assets/%s-cmd", img))
+			buf, err := os.ReadFile(fmt.Sprintf("./assets/%s-cmd", image))
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
Those changes will print the following error message if no command is specified and tar is not found:

```
panic: stat ./assets/hello-world.tar.gz: no such file or directory

goroutine 1 [running]:
main.main()
        /home/davide/chroot-containers/chrun.go:23 +0x30f
```

Otherwise it would fail saying `./assets/%s-cmd` not found which might be confusing.

It doesn't pull the content by default (like docker) since run requires root permissions, while tars don't need to be owned by root.